### PR TITLE
Addmake target to support recovery test with disabled chaos monkey #32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new make target to support recovery test for FS stacks with disabled chaos monkey #32
 
 ## [1.0.0] - 2019-05-23
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ test-provisioning-readiness: test-successful-provisioning-orchestrator test-read
 
 test-recovery: test-recovery-orchestrator test-recovery-author-dispatcher test-recovery-publish-dispatcher test-recovery-publish test-recovery-chaosmonkey
 
+test-recovery-with-disabled-chaosmonkey: test-recovery-orchestrator test-recovery-author-dispatcher test-recovery-publish-dispatcher test-recovery-publish
+
 test-readiness-author:
 	inspec exec . --show-progress --controls=\
 	  author-instances-ready


### PR DESCRIPTION
Add new make target to support recovery test for FS stacks with disabled 
chaos monkey #32